### PR TITLE
Setup Frontend Auth, with Backend fixes

### DIFF
--- a/ShepardsPies-Client/src/App.jsx
+++ b/ShepardsPies-Client/src/App.jsx
@@ -1,35 +1,36 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useEffect, useState } from "react";
+import "./App.css";
+import "bootstrap/dist/css/bootstrap.min.css";
+import { tryGetLoggedInUser } from "./Managers/authManager";
+import { Spinner } from "reactstrap";
+import NavBar from "./Components/NavBar";
+import ApplicationViews from "./Components/ApplicationViews";
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [loggedInUser, setLoggedInUser] = useState();
+
+  useEffect(() => {
+    // user will be null if not authenticated
+    tryGetLoggedInUser().then((user) => {
+      setLoggedInUser(user);
+    });
+  }, []);
+
+  // wait to get a definite logged-in state before rendering
+  if (loggedInUser === undefined) {
+    return <Spinner />;
+  }
 
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <NavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser} />
+      <ApplicationViews
+        loggedInUser={loggedInUser}
+        setLoggedInUser={setLoggedInUser}
+      />
     </>
-  )
+  );
 }
 
-export default App
+export default App;
+

--- a/ShepardsPies-Client/src/Components/ApplicationViews.jsx
+++ b/ShepardsPies-Client/src/Components/ApplicationViews.jsx
@@ -1,0 +1,23 @@
+
+
+
+
+export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
+  return (
+    <>
+    <Routes>
+      <Route path="/">
+        </Route>
+        <Route
+          path="login"
+          element={<Login setLoggedInUser={setLoggedInUser} />}
+        />
+        <Route
+          path="register"
+          element={<Register setLoggedInUser={setLoggedInUser} />}
+        />
+      <Route path="*" element={<p>Whoops, nothing here...</p>} />
+    </Routes>
+    </>
+  );
+}

--- a/ShepardsPies-Client/src/Components/NavBar.jsx
+++ b/ShepardsPies-Client/src/Components/NavBar.jsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { NavLink as RRNavLink } from "react-router-dom";
+import {
+Button,
+Collapse,
+Nav,
+NavLink,
+NavItem,
+Navbar,
+NavbarBrand,
+NavbarToggler,
+} from "reactstrap";
+import { logout } from "../Managers/authManager";
+
+export default function NavBar({ loggedInUser, setLoggedInUser }) {
+const [open, setOpen] = useState(false);
+
+const toggleNavbar = () => setOpen(!open);
+
+return (
+    <div>
+    <Navbar color="light" light fixed="true" expand="lg">
+        <NavbarBrand className="mr-auto" tag={RRNavLink} to="/">
+        Shepherd's Pies
+        </NavbarBrand>
+        {loggedInUser ? (
+        <>
+            <NavbarToggler onClick={toggleNavbar} />
+            <Collapse isOpen={open} navbar>
+            <Nav navbar></Nav>
+            </Collapse>
+            <Button
+            color="primary"
+            onClick={(e) => {
+                e.preventDefault();
+                setOpen(false);
+                logout().then(() => {
+                setLoggedInUser(null);
+                setOpen(false);
+                });
+            }}
+            >
+            Logout
+            </Button>
+        </>
+        ) : (
+        <Nav navbar>
+            <NavItem>
+            <NavLink tag={RRNavLink} to="/login">
+                <Button color="primary">Login</Button>
+            </NavLink>
+            </NavItem>
+        </Nav>
+        )}
+    </Navbar>
+    </div>
+);
+}

--- a/ShepardsPies-Client/src/Components/auth/AuthorizedRoute.jsx
+++ b/ShepardsPies-Client/src/Components/auth/AuthorizedRoute.jsx
@@ -1,0 +1,19 @@
+import { Navigate } from "react-router-dom";
+
+// This component returns a Route that either display the prop element
+// or navigates to the login. If roles are provided, the route will require
+// all of the roles when all is true, or any of the roles when all is false
+export const AuthorizedRoute = ({ children, loggedInUser, roles, all }) => {
+  let authed = false;
+  if (loggedInUser) {
+    if (roles && roles.length) {
+      authed = all
+        ? roles.every((r) => loggedInUser.roles.includes(r))
+        : roles.some((r) => loggedInUser.roles.includes(r));
+    } else {
+      authed = true;
+    }
+  }
+
+  return authed ? children : <Navigate to="/login" />;
+};

--- a/ShepardsPies-Client/src/Components/auth/Login.jsx
+++ b/ShepardsPies-Client/src/Components/auth/Login.jsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { login } from "../../managers/authManager";
+import { Button, FormFeedback, FormGroup, Input, Label } from "reactstrap";
+
+export default function Login({ setLoggedInUser }) {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [failedLogin, setFailedLogin] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login(email, password).then((user) => {
+      if (!user) {
+        setFailedLogin(true);
+      } else {
+        setLoggedInUser(user);
+        navigate("/");
+      }
+    });
+  };
+
+  return (
+    <div className="container" style={{ maxWidth: "500px" }}>
+      <h3>Login</h3>
+      <FormGroup>
+        <Label>Email</Label>
+        <Input
+          invalid={failedLogin}
+          type="text"
+          value={email}
+          onChange={(e) => {
+            setFailedLogin(false);
+            setEmail(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>Password</Label>
+        <Input
+          invalid={failedLogin}
+          type="password"
+          value={password}
+          onChange={(e) => {
+            setFailedLogin(false);
+            setPassword(e.target.value);
+          }}
+        />
+        <FormFeedback>Login failed.</FormFeedback>
+      </FormGroup>
+
+      <Button color="primary" onClick={handleSubmit}>
+        Login
+      </Button>
+      <p>
+        Not signed up? Register <Link to="/register">here</Link>
+      </p>
+    </div>
+  );
+}

--- a/ShepardsPies-Client/src/Components/auth/Register.jsx
+++ b/ShepardsPies-Client/src/Components/auth/Register.jsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { register } from "../../managers/authManager";
+import { Link, useNavigate } from "react-router-dom";
+import { Button, FormFeedback, FormGroup, Input, Label } from "reactstrap";
+
+export default function Register({ setLoggedInUser }) {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [userName, setUserName] = useState("");
+  const [email, setEmail] = useState("");
+  const [address, setAddress] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const [passwordMismatch, setPasswordMismatch] = useState();
+  const [registrationFailure, setRegistrationFailure] = useState(false);
+
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (password !== confirmPassword) {
+      setPasswordMismatch(true);
+    } else {
+      const newUser = {
+        firstName,
+        lastName,
+        userName,
+        email,
+        address,
+        password,
+      };
+      register(newUser).then((user) => {
+        if (user) {
+          setLoggedInUser(user);
+          navigate("/");
+        } else {
+          setRegistrationFailure(true);
+        }
+      });
+    }
+  };
+
+  return (
+    <div className="container" style={{ maxWidth: "500px" }}>
+      <h3>Sign Up</h3>
+      <FormGroup>
+        <Label>First Name</Label>
+        <Input
+          type="text"
+          value={firstName}
+          onChange={(e) => {
+            setFirstName(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>Last Name</Label>
+        <Input
+          type="text"
+          value={lastName}
+          onChange={(e) => {
+            setLastName(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>Email</Label>
+        <Input
+          type="email"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>User Name</Label>
+        <Input
+          type="text"
+          value={userName}
+          onChange={(e) => {
+            setUserName(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>Address</Label>
+        <Input
+          type="text"
+          value={address}
+          onChange={(e) => {
+            setAddress(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>Password</Label>
+        <Input
+          invalid={passwordMismatch}
+          type="password"
+          value={password}
+          onChange={(e) => {
+            setPasswordMismatch(false);
+            setPassword(e.target.value);
+          }}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label> Confirm Password</Label>
+        <Input
+          invalid={passwordMismatch}
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => {
+            setPasswordMismatch(false);
+            setConfirmPassword(e.target.value);
+          }}
+        />
+        <FormFeedback>Passwords do not match!</FormFeedback>
+      </FormGroup>
+      <p style={{ color: "red" }} hidden={!registrationFailure}>
+        Registration Failure
+      </p>
+      <Button
+        color="primary"
+        onClick={handleSubmit}
+        disabled={passwordMismatch}
+      >
+        Register
+      </Button>
+      <p>
+        Already signed up? Log in <Link to="/login">here</Link>
+      </p>
+    </div>
+  );
+}

--- a/ShepardsPies-Client/src/Managers/authManager.js
+++ b/ShepardsPies-Client/src/Managers/authManager.js
@@ -1,0 +1,39 @@
+const _apiUrl = "/api/auth";
+
+export const login = (email, password) => {
+  return fetch(_apiUrl + "/login", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      Authorization: `Basic ${btoa(`${email}:${password}`)}`,
+    },
+  }).then((res) => {
+    if (res.status !== 200) {
+      return Promise.resolve(null);
+    } else {
+      return tryGetLoggedInUser();
+    }
+  });
+};
+
+export const logout = () => {
+  return fetch(_apiUrl + "/logout");
+};
+
+export const tryGetLoggedInUser = () => {
+  return fetch(_apiUrl + "/me").then((res) => {
+    return res.status === 401 ? Promise.resolve(null) : res.json();
+  });
+};
+
+export const register = (userProfile) => {
+  userProfile.password = btoa(userProfile.password);
+  return fetch(_apiUrl + "/register", {
+    credentials: "same-origin",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(userProfile),
+  }).then(() => tryGetLoggedInUser());
+};

--- a/ShepardsPies-Client/src/main.jsx
+++ b/ShepardsPies-Client/src/main.jsx
@@ -1,10 +1,9 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
+  <BrowserRouter>
     <App />
-  </StrictMode>,
+  </BrowserRouter>,
 )

--- a/ShepardsPiesAPI/Controllers/AuthController.cs
+++ b/ShepardsPiesAPI/Controllers/AuthController.cs
@@ -1,0 +1,164 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using System.Text;
+using ShepardsPiesAPI.Models;
+using ShepardsPiesAPI.Models.DTOs;
+using ShepardsPiesAPI.Data;
+
+namespace ShepardsPiesAPI.Controllers;
+
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private ShepardsPiesAPIDbContext _dbContext;
+    private UserManager<IdentityUser> _userManager;
+
+    public AuthController(ShepardsPiesAPIDbContext context, UserManager<IdentityUser> userManager)
+    {
+        _dbContext = context;
+        _userManager = userManager;
+    }
+
+    [HttpPost("login")]
+    public IActionResult Login([FromHeader(Name = "Authorization")] string authHeader)
+    {
+        try
+        {
+            string encodedCreds = authHeader.Substring(6).Trim();
+            string creds = Encoding
+            .GetEncoding("iso-8859-1")
+            .GetString(Convert.FromBase64String(encodedCreds));
+
+            // Get email and password
+            int separator = creds.IndexOf(':');
+            string email = creds.Substring(0, separator);
+            string password = creds.Substring(separator + 1);
+
+            var user = _dbContext.Users.Where(u => u.Email == email).FirstOrDefault();
+            var userRoles = _dbContext.UserRoles.Where(ur => ur.UserId == user.Id).ToList();
+            var hasher = new PasswordHasher<IdentityUser>();
+            var result = hasher.VerifyHashedPassword(user, user.PasswordHash, password);
+            if (user != null && result == PasswordVerificationResult.Success)
+            {
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                    new Claim(ClaimTypes.Name, user.UserName.ToString()),
+                    new Claim(ClaimTypes.Email, user.Email)
+
+                };
+
+                foreach (var userRole in userRoles)
+                {
+                    var role = _dbContext.Roles.FirstOrDefault(r => r.Id == userRole.RoleId);
+                    claims.Add(new Claim(ClaimTypes.Role, role.Name));
+                }
+
+                var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+
+                HttpContext.SignInAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                new ClaimsPrincipal(claimsIdentity)).Wait();
+
+                return Ok();
+            }
+
+            return new UnauthorizedResult();
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet]
+    [Route("logout")]
+    [Authorize(AuthenticationSchemes = CookieAuthenticationDefaults.AuthenticationScheme)]
+    public IActionResult Logout()
+    {
+        try
+        {
+            HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme).Wait();
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500);
+        }
+    }
+
+    [HttpGet("Me")]
+    [Authorize]
+    public IActionResult Me()
+    {
+        var identityUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var profile = _dbContext.UserProfiles.SingleOrDefault(up => up.IdentityUserId == identityUserId);
+        var roles = User.FindAll(ClaimTypes.Role).Select(r => r.Value).ToList();
+        if (profile != null)
+        {
+            var userDto = new UserProfileDTO
+            {
+                Id = profile.Id,
+                FirstName = profile.FirstName,
+                LastName = profile.LastName,
+                Address = profile.Address,
+                IdentityUserId = identityUserId,
+                UserName = User.FindFirstValue(ClaimTypes.Name),
+                Email = User.FindFirstValue(ClaimTypes.Email),
+                Roles = roles
+            };
+
+            return Ok(userDto);
+        }
+        return NotFound();
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegistrationDTO registration)
+    {
+        var user = new IdentityUser
+        {
+            UserName = registration.UserName,
+            Email = registration.Email
+        };
+
+        var password = Encoding
+            .GetEncoding("iso-8859-1")
+            .GetString(Convert.FromBase64String(registration.Password));
+
+        var result = await _userManager.CreateAsync(user, password);
+        if (result.Succeeded)
+        {
+            _dbContext.UserProfiles.Add(new UserProfile
+            {
+                FirstName = registration.FirstName,
+                LastName = registration.LastName,
+                Address = registration.Address,
+                IdentityUserId = user.Id,
+            });
+            _dbContext.SaveChanges();
+
+            var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                    new Claim(ClaimTypes.Name, user.UserName.ToString()),
+                    new Claim(ClaimTypes.Email, user.Email)
+
+                };
+            var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+
+            HttpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            new ClaimsPrincipal(claimsIdentity)).Wait();
+
+            return Ok();
+        }
+        return StatusCode(500);
+    }
+}

--- a/ShepardsPiesAPI/Models/DTO/RegistrationDTO.cs
+++ b/ShepardsPiesAPI/Models/DTO/RegistrationDTO.cs
@@ -1,0 +1,12 @@
+namespace ShepardsPiesAPI.Models.DTOs;
+
+public class RegistrationDTO
+{
+    public string Email { get; set; }
+    public string Password { get; set; }
+    public string UserName { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Address { get; set; }
+
+}

--- a/ShepardsPiesAPI/Models/DTO/UserProfileDTO.cs
+++ b/ShepardsPiesAPI/Models/DTO/UserProfileDTO.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
+
+namespace ShepardsPiesAPI.Models.DTOs;
+
+public class UserProfileDTO
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Address { get; set; }
+    public string Email { get; set; }
+
+    public string UserName { get; set; }
+    public List<string> Roles { get; set; }
+
+    public string IdentityUserId { get; set; }
+
+    public IdentityUser IdentityUser { get; set; }
+
+}

--- a/ShepardsPiesAPI/Models/UserProfile.cs
+++ b/ShepardsPiesAPI/Models/UserProfile.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace ShepardsPiesAPI.Models;
+
+public class UserProfile
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Address { get; set; }
+
+    public string IdentityUserId { get; set; }
+
+    public IdentityUser IdentityUser { get; set; }
+
+}


### PR DESCRIPTION
# Pull Request: Setup Frontend Auth, with Backend fixes

## Overview
This PR wires up full authentication support in both the React frontend and ASP.NET Core backend. Users can now register, log in, and access protected routes.

### Frontend
- **App.jsx**  
  - Added `tryGetLoggedInUser` in `useEffect`  
  - Show `<Spinner />` while auth state is resolving  
  - Hooked up `<NavBar>` and `<ApplicationViews>` with `loggedInUser` state  
- **Components/**  
  - **NavBar.jsx** – login/logout buttons, responsive collapse  
  - **ApplicationViews.jsx** – top-level `<Routes>` for `/login`, `/register`, fallback  
  - **auth/AuthorizedRoute.jsx** – HOC that guards routes by role or authentication  
  - **auth/Login.jsx** – login form with validation, calls `authManager.login`  
  - **auth/Register.jsx** – registration form with password confirmation, calls `authManager.register`  
- **Managers/authManager.js**  
  - `login`, `logout`, `tryGetLoggedInUser`, `register` wrapping fetch calls to `/api/auth`

### Backend
- **Controllers/AuthController.cs**  
  - `POST /api/auth/login` — Basic header parsing, cookie sign-in  
  - `GET  /api/auth/logout` — clears cookie  
  - `GET  /api/auth/me`   — returns `UserProfileDTO` for current user  
  - `POST /api/auth/register` — creates IdentityUser, UserProfile, signs in  
- **Models/DTO/**  
  - `RegistrationDTO.cs`  
  - `UserProfileDTO.cs`  
- **Models/UserProfile.cs**  
  - Stores first/last name, address, IdentityUserId
